### PR TITLE
Add bower configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 *.txt
 node_modules
+bower_components
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Quick Installation
 
 1. Download <a class='download plain' href="https://raw.githubusercontent.com/adrianmay/rhaboo/master/rhaboo.min.js" download>rhaboo.min.js</a> and include it with a script tag.
 
-2. Install with 
+2. Install with npm:
 
 ```
    npm install rhaboo
 ```
+
 
 and point your browser at: 
 
@@ -45,6 +46,16 @@ to check that it installed ok. Include the library in your HTML file:
 
 ```
    <script src="node_modules/rhaboo/rhaboo.min.js"></script>
+```
+
+3. Install with Bower:
+```
+   bower install rhaboo --save
+```
+
+and then include the library in your HTML file:
+```
+   <script src="bower_components/rhaboo/rhaboo.min.js"></script>
 ```
 
 Installation for building or generating tests

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "rhaboo",
+  "description": "Persistent JS Objects",
+  "main": "./rhaboo.min.js",
+  "authors": [
+    "Adrian May"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "javascript",
+    "persistence",
+    "persistent",
+    "objects",
+    "localStorage"
+  ],
+  "homepage": "http://adrianmay.github.io/rhaboo",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
My team needed this on bower for our toolchain. I ended up deploying it to bower with another name for now, but it'd be nice if the original repo had it deployed too. 

To register on bower from this repo, however, some more things will need to be added:
* At least a v3.2.4 tag on Git, as there are no tags on the repo
  * This can be added either from the command line and then pushed to GitHub, or through GitHub's interface
  * See [here](https://git-scm.com/book/en/v2/Git-Basics-Tagging) for more information.
  * On my fork, I created it using `$ git tag -a v3.2.4-bower -m "Rhaboo version 3.2.4 with bower"`
* Register to bower using the owner's credentials.
  * This was necessary for the release to be made, as nobody else can publish to the bower registry.
  * It should be as simple as `$ bower register rhaboo git://github.com/adrianmay/rhaboo.git `

I also took the liberty to add a simple documentation for the bower installation too. After this is merged, this could also be of use: [bower badge]( http://benschwarz.github.io/bower-badges/).